### PR TITLE
feat: use json-path for path param

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,7 +101,7 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, expect.any(String));
       expect(mockMutation).toHaveBeenCalledTimes(1);
     });
 
@@ -110,9 +110,24 @@ describe("traverse", () => {
       const mockMutation = jest.fn((s) => s);
       traverse(schema, mockMutation);
       expect(mockMutation).toHaveBeenCalledTimes(3);
-      expect(mockMutation).toHaveBeenNthCalledWith(1, true, false, "/properties/a");
-      expect(mockMutation).toHaveBeenNthCalledWith(2, false, false, "/properties/b");
-      expect(mockMutation).toHaveBeenNthCalledWith(3, schema, false, "");
+      expect(mockMutation).toHaveBeenNthCalledWith(
+        1,
+        true,
+        false,
+        expect.any(String)
+      );
+      expect(mockMutation).toHaveBeenNthCalledWith(
+        2,
+        false,
+        false,
+        expect.any(String)
+      );
+      expect(mockMutation).toHaveBeenNthCalledWith(
+        3,
+        schema,
+        false,
+        expect.any(String)
+      );
     });
 
     it("accepts patternProperties", () => {
@@ -125,9 +140,9 @@ describe("traverse", () => {
       const mockMutation = jest.fn((s) => s);
       traverse(schema, mockMutation);
       expect(mockMutation).toHaveBeenCalledTimes(3);
-      expect(mockMutation).toHaveBeenNthCalledWith(1, a, false, "/patternProperties/*.");
-      expect(mockMutation).toHaveBeenNthCalledWith(2, b, false, "/patternProperties/x-^");
-      expect(mockMutation).toHaveBeenNthCalledWith(3, schema, false, "");
+      expect(mockMutation).toHaveBeenNthCalledWith(1, a, false, "$.patternProperties.*.");
+      expect(mockMutation).toHaveBeenNthCalledWith(2, b, false, "$.patternProperties.x-^");
+      expect(mockMutation).toHaveBeenNthCalledWith(3, schema, false, "$");
     });
 
     it("allows booleans that are created via boolean class and new", () => {
@@ -138,13 +153,13 @@ describe("traverse", () => {
       traverse(schema, mockMutation);
       expect(mockMutation).toHaveBeenCalledTimes(3);
 
-      expect(mockMutation).toHaveBeenNthCalledWith(1, a, false, "/properties/a");
-      expect(mockMutation).not.toHaveBeenNthCalledWith(1, true, false, "/properties/a");
+      expect(mockMutation).toHaveBeenNthCalledWith(1, a, false, "$.properties.a");
+      expect(mockMutation).not.toHaveBeenNthCalledWith(1, true, false, "$.properties.a");
 
-      expect(mockMutation).toHaveBeenNthCalledWith(2, b, false, "/properties/b");
-      expect(mockMutation).not.toHaveBeenNthCalledWith(2, false, false, "/properties/b");
+      expect(mockMutation).toHaveBeenNthCalledWith(2, b, false, "$.properties.b");
+      expect(mockMutation).not.toHaveBeenNthCalledWith(2, false, false, "$.properties.b");
 
-      expect(mockMutation).toHaveBeenNthCalledWith(3, schema, false, "");
+      expect(mockMutation).toHaveBeenNthCalledWith(3, schema, false, "$");
     });
 
     it("items is a boolean", () => {
@@ -152,8 +167,8 @@ describe("traverse", () => {
       const mockMutation = jest.fn((s) => s);
       traverse(schema, mockMutation);
       expect(mockMutation).toHaveBeenCalledTimes(2);
-      expect(mockMutation).toHaveBeenNthCalledWith(1, true, false, "");
-      expect(mockMutation).toHaveBeenNthCalledWith(2, schema, false, "");
+      expect(mockMutation).toHaveBeenNthCalledWith(1, true, false, "$.items");
+      expect(mockMutation).toHaveBeenNthCalledWith(2, schema, false, "$");
     });
 
     it("doesnt skip boolean schemas that it has not seen", () => {
@@ -185,9 +200,21 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.properties.a, false, "/properties/a");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.properties.b, false, "/properties/b");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.properties.a,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.properties.b,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema,
+        false,
+        expect.any(String),
+      );
       expect(mockMutation).toHaveBeenCalledTimes(3);
     });
 
@@ -199,8 +226,8 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalProperties, false, "/additionalProperties");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalProperties, false, "$.additionalProperties");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "$");
       expect(mockMutation).toHaveBeenCalledTimes(2);
     });
 
@@ -217,12 +244,22 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      const expectedPath1 = "/additionalProperties/properties/c";
-      const expectedPath2 = "/additionalProperties/properties/d";
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalProperties, false, "/additionalProperties");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalProperties.properties.c, false, expectedPath1);
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalProperties.properties.d, false, expectedPath2);
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalProperties,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalProperties.properties.c,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalProperties.properties.d,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, expect.any(String));
       expect(mockMutation).toHaveBeenCalledTimes(4);
     });
 
@@ -234,8 +271,12 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalItems, false, "/additionalItems");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalItems,
+        false,
+        expect.any(String),
+      );
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, expect.any(String));
       expect(mockMutation).toHaveBeenCalledTimes(2);
     });
 
@@ -252,12 +293,26 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation);
 
-      const expectedPath1 = "/additionalItems/properties/c";
-      const expectedPath2 = "/additionalItems/properties/d";
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalItems, false, "/additionalItems");
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalItems.properties.c, false, expectedPath1);
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.additionalItems.properties.d, false, expectedPath2);
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalItems,
+        false,
+        expect.any(String)
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalItems.properties.c,
+        false,
+        expect.any(String)
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema.additionalItems.properties.d,
+        false,
+        expect.any(String)
+      );
+      expect(mockMutation).toHaveBeenCalledWith(
+        testSchema,
+        false,
+        expect.any(String)
+      );
       expect(mockMutation).toHaveBeenCalledTimes(4);
     });
 
@@ -484,7 +539,7 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation, { skipFirstMutation: true });
 
-      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, expect.any, "");
+      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, expect.any, expect.any);
       expect(mockMutation).toHaveBeenCalledTimes(2);
     });
 
@@ -494,7 +549,7 @@ describe("traverse", () => {
 
       traverse(testSchema, mockMutation, { skipFirstMutation: true });
 
-      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, expect.any, "");
+      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, expect.any, expect.any);
       expect(mockMutation).toHaveBeenCalledTimes(0);
     });
 
@@ -522,11 +577,11 @@ describe("traverse", () => {
       const mockMutation2 = jest.fn((mockS) => mockS);
       traverse(testSchema2, mockMutation2, { skipFirstMutation: true, mutable: true }) as JSONSchemaObject;
 
-      expect(mockMutation1).toHaveBeenCalledWith(testSchema1, true, "/properties/skipFirstCycle");
+      expect(mockMutation1).toHaveBeenCalledWith(testSchema1, true, "$.properties.skipFirstCycle");
       expect(mockMutation1).toHaveBeenCalledTimes(1);
       expect((testSchema1.properties as Properties).skipFirstCycle).toBe(testSchema1);
 
-      expect(mockMutation2).toHaveBeenCalledWith(testSchema2, true, "");
+      expect(mockMutation2).toHaveBeenCalledWith(testSchema2, true, "$");
       expect(mockMutation2).toHaveBeenCalledTimes(1);
       expect(testSchema2.items).toBe(testSchema2);
     });
@@ -552,8 +607,8 @@ describe("traverse", () => {
 
       traverse(testSchema as JSONSchema, mockMutation, { mutable: true });
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema.properties.foo, true, "/properties/foo");
-      expect(mockMutation).not.toHaveBeenCalledWith(testSchema.properties.foo, false, "/properties/foo");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema.properties.foo, true, "$.properties.foo");
+      expect(mockMutation).not.toHaveBeenCalledWith(testSchema.properties.foo, false, "$.properties.foo");
       expect(mockMutation).toHaveBeenCalledTimes(2);
     });
 
@@ -570,8 +625,8 @@ describe("traverse", () => {
 
       traverse(testSchema as JSONSchema, mockMutation, { mutable: true });
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, true, "");
-      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, true, "$");
+      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, false, "$");
     });
 
     it("true when the cycle is inside oneOf", () => {
@@ -591,8 +646,8 @@ describe("traverse", () => {
 
       traverse(testSchema as JSONSchema, mockMutation, { mutable: false });
 
-      expect(mockMutation).toHaveBeenCalledWith(testSchema, true, "");
-      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, false, "");
+      expect(mockMutation).toHaveBeenCalledWith(testSchema, true, "$");
+      expect(mockMutation).not.toHaveBeenCalledWith(testSchema, false, "$");
     });
   });
 
@@ -614,10 +669,10 @@ describe("traverse", () => {
 
       traverse(testSchema as JSONSchema, mockMutation, { bfs: true, });
 
-      const expectedPath1 = "/properties/foo/items/0";
-      const expectedPath2 = "/properties/foo/items/1";
-      expect(mockMutation).nthCalledWith(1, testSchema, false, "");
-      expect(mockMutation).nthCalledWith(2, testSchema.properties.foo, false, "/properties/foo");
+      const expectedPath1 = "$.properties.foo.items[0]";
+      const expectedPath2 = "$.properties.foo.items[1]";
+      expect(mockMutation).nthCalledWith(1, testSchema, false, "$");
+      expect(mockMutation).nthCalledWith(2, testSchema.properties.foo, false, "$.properties.foo");
       expect(mockMutation).nthCalledWith(3, testSchema.properties.foo.items[0], false, expectedPath1);
       expect(mockMutation).nthCalledWith(4, testSchema.properties.foo.items[1], false, expectedPath2);
     });
@@ -639,10 +694,10 @@ describe("traverse", () => {
 
       traverse(testSchema as JSONSchema, mockMutation, { bfs: true, mutable: true });
 
-      const expectedPath1 = "/properties/foo/items/0";
-      const expectedPath2 = "/properties/foo/items/1";
-      expect(mockMutation).nthCalledWith(1, testSchema, false, "");
-      expect(mockMutation).nthCalledWith(2, testSchema.properties.foo, false, "/properties/foo");
+      const expectedPath1 = "$.properties.foo.items[0]";
+      const expectedPath2 = "$.properties.foo.items[1]";
+      expect(mockMutation).nthCalledWith(1, testSchema, false, "$");
+      expect(mockMutation).nthCalledWith(2, testSchema.properties.foo, false, "$.properties.foo");
       expect(mockMutation).nthCalledWith(3, testSchema.properties.foo.items[0], false, expectedPath1);
       expect(mockMutation).nthCalledWith(4, testSchema.properties.foo.items[1], false, expectedPath2);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { JSONSchema, JSONSchemaObject, PatternProperties } from "@json-schema-to
  *
  * @param schema The schema or subschema node being traversed
  * @param isCycle false if the schema passed is not the root of a detected cycle. Useful for special handling of cycled schemas.
- * @param path json path string separated by periods
+ * @param path json-path string in dot-notation as per [draft-goessner-dispatch-jsonpath-00](https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html#name-overview-of-jsonpath-expres)
  */
 export type MutationFunction = (schema: JSONSchema, isCycle: boolean, path: string,) => JSONSchema;
 
@@ -44,7 +44,13 @@ export const defaultOptions: TraverseOptions = {
 };
 
 const jsonPathStringify = (s: string[]) => {
-  return s.map(i => i === "" ? i.toString() : ("/" + i.toString())).join("");
+  return s.map((i) => {
+    if (i === "") {
+      return '$';
+    } else {
+      return `.${i}`;
+    }
+  }).join("");
 };
 
 const isCycle = (s: JSONSchema, recursiveStack: JSONSchema[]): JSONSchema | false => {
@@ -142,17 +148,17 @@ export default function traverse(
 
   if (schema.anyOf) {
     mutableSchema.anyOf = schema.anyOf.map((x, i) => {
-      const result = rec(x, [...pathStack, "anyOf", i.toString()]);
+      const result = rec(x, [...pathStack, `anyOf[${i}]`]);
       return result;
     });
   } else if (schema.allOf) {
     mutableSchema.allOf = schema.allOf.map((x, i) => {
-      const result = rec(x, [...pathStack, "allOf", i.toString()]);
+      const result = rec(x, [...pathStack, `allOf[${i}]`]);
       return result;
     });
   } else if (schema.oneOf) {
     mutableSchema.oneOf = schema.oneOf.map((x, i) => {
-      const result = rec(x, [...pathStack, "oneOf", i.toString()]);
+      const result = rec(x, [...pathStack, `oneOf[${i}]`]);
       return result;
     });
   } else {
@@ -161,7 +167,7 @@ export default function traverse(
     if (schema.items) {
       if (schema.items instanceof Array) {
         mutableSchema.items = schema.items.map((x, i) => {
-          const result = rec(x, [...pathStack, "items", i.toString()]);
+          const result = rec(x, [...pathStack, `items[${i}]`]);
           return result;
         });
       } else {
@@ -186,7 +192,7 @@ export default function traverse(
             traverseOptions,
             depth + 1,
             recursiveStack,
-            pathStack,
+            [...pathStack, "items"],
             prePostMap,
             cycleSet,
           );

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -1,0 +1,125 @@
+import traverse from "./";
+import { JSONSchema } from "@json-schema-tools/meta-schema";
+
+describe("traverse paths", () => {
+  const test = (s: JSONSchema, paths: string[]) => {
+    const mutator = jest.fn((s) => s);
+
+    traverse(s, mutator);
+
+    paths.forEach((path) => {
+      expect(mutator).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Boolean),
+        path
+      );
+    });
+  };
+
+  describe("schema is a boolean", () => {
+    it("allows root schema as boolean", () => {
+      const testSchema: any = true;
+      test(testSchema, ["$"]);
+    });
+  });
+
+  describe("schema.properties", () => {
+    it("allows traversing property subschemas", () => {
+      const testSchema: any = {
+        properties: {
+          a: {},
+          b: {},
+        },
+      };
+      test(testSchema, [
+        "$",
+        "$.properties.a",
+        "$.properties.b",
+      ]);
+    });
+    it("allows boolean subschema in properties", () => {
+      const testSchema = { type: "object", properties: { a: true, b: false } } as JSONSchema;
+      test(testSchema, [
+        "$",
+        "$.properties.a",
+        "$.properties.b",
+      ]);
+    });
+  });
+
+  describe("schema.additionalProperties", () => {
+    it("allows boolean", () => {
+      const testSchema: any = {
+        additionalProperties: true
+      };
+      test(testSchema, ["$", "$.additionalProperties"]);
+    });
+
+    it("allows subschema", () => {
+      const testSchema: any = {
+        additionalProperties: {
+          properties: {
+            c: {},
+            d: {},
+          },
+        },
+      };
+
+      test(testSchema, [
+        "$",
+        "$.additionalProperties",
+        "$.additionalProperties.properties.c",
+        "$.additionalProperties.properties.d",
+      ]);
+    });
+  });
+
+  describe("schema.additionalItems", () => {
+    it("allows boolean", () => {
+      const testSchema: any = {
+        additionalItems: true
+      };
+      test(testSchema, ["$", "$.additionalItems"]);
+    });
+
+    it("allows subschema", () => {
+      const testSchema: any = {
+        additionalItems: {
+          properties: {
+            c: {},
+            d: {},
+          },
+        },
+      };
+
+      test(testSchema, [
+        "$",
+        "$.additionalItems",
+        "$.additionalItems.properties.c",
+        "$.additionalItems.properties.d",
+      ]);
+    });
+  });
+
+  describe("schema.items", () => {
+    it("allows an array of schema", () => {
+      const testSchema = {
+        type: "array",
+        items: [
+          { type: "string" },
+          { type: "number" },
+        ]
+      } as JSONSchema;
+      test(testSchema, ["$.items[0]"]);
+    });
+
+    it("allows a schema", () => {
+      const testSchema = {
+        type: "array",
+        items: { type: "number" },
+      } as JSONSchema;
+
+      test(testSchema, ["$.items"]);
+    });
+  });
+});


### PR DESCRIPTION
also fixes a bug with `items` not showing up in path when its an object.