### PR TITLE
Add entry wrapper for traverse

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1041,6 +1041,18 @@ describe("traverse", () => {
       testCalls(mockMutation, testSchema.properties.foo.items[1], false, 4);
     });
   });
+
+  describe("entry wrapper", () => {
+    it("wraps internal recursion", () => {
+      const mod = require("./");
+      const spy = jest.spyOn(mod, "default");
+      const schema = { anyOf: [{}] };
+      const mutation = jest.fn((s) => s);
+      mod.default(schema as JSONSchema, mutation);
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+  });
 });
 
 describe("Mutability settings", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,10 @@ const last = (i: JSONSchema[], skip = 1): JSONSchema => {
  *              some of the options.
  *
  */
-export default function traverse(
+export function traverseInternal(
   schema: JSONSchema,
   mutation: MutationFunction,
-  traverseOptions = defaultOptions,
+  traverseOptions: TraverseOptions,
   depth = 0,
   recursiveStack: JSONSchema[] = [],
   mutableStack: JSONSchema[] = [],
@@ -93,7 +93,7 @@ export default function traverse(
   prePostMap: Array<[JSONSchema, JSONSchema]> = [],
   cycleSet: JSONSchema[] = [],
 ): JSONSchema {
-  const opts = { ...defaultOptions, ...traverseOptions }; // would be nice to make an 'entry' func when we get around to optimizations
+  const opts = traverseOptions;
 
   // booleans are a bit messed. Since all other schemas are objects (non-primitive type
   // which gets a new address in mem) for each new JS refer to one of 2 memory addrs, and
@@ -161,7 +161,7 @@ export default function traverse(
     }
 
     // else
-    return traverse(
+    return traverseInternal(
       s,
       mutation,
       traverseOptions,
@@ -216,7 +216,7 @@ export default function traverse(
             mutableSchema.items = cycledMutableSchema;
           }
         } else {
-          mutableSchema.items = traverse(
+          mutableSchema.items = traverseInternal(
             schema.items,
             mutation,
             traverseOptions,
@@ -282,4 +282,23 @@ export default function traverse(
       last(mutableStack)
     );
   }
+}
+
+export default function traverse(
+  schema: JSONSchema,
+  mutation: MutationFunction,
+  traverseOptions: TraverseOptions = defaultOptions,
+) {
+  const opts = { ...defaultOptions, ...traverseOptions };
+  return traverseInternal(
+    schema,
+    mutation,
+    opts,
+    0,
+    [],
+    [],
+    [],
+    [],
+    [],
+  );
 }


### PR DESCRIPTION
## Summary
- create `traverseInternal` and call it from new entry wrapper `traverse`
- add tests checking the wrapper is used once during traversal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68550cea6714832fa86e14b27d58716b