### PR TITLE
Add BFS cycle tests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1040,6 +1040,57 @@ describe("traverse", () => {
       testCalls(mockMutation, testSchema.properties.foo.items[0], false, 3);
       testCalls(mockMutation, testSchema.properties.foo.items[1], false, 4);
     });
+
+    it("handles basic cycles when bfs is true", () => {
+      const schema = { type: "object", properties: { foo: {} } } as any;
+      schema.properties.foo = schema;
+      const mockMutation = jest.fn((s) => s);
+
+      traverse(schema as JSONSchema, mockMutation, { bfs: true });
+
+      expect(mockMutation).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles chained cycles when bfs is true", () => {
+      const schema = {
+        title: "1",
+        type: "object",
+        properties: {
+          foo: {
+            title: "2",
+            items: [
+              {
+                title: "3",
+                type: "array",
+                items: { title: "4" },
+              },
+            ],
+          },
+        },
+      } as any;
+      schema.properties.foo.items[0].items = schema;
+      const mockMutation = jest.fn((s) => s);
+
+      traverse(schema as JSONSchema, mockMutation, { bfs: true });
+
+      expect(mockMutation).toHaveBeenCalledTimes(3);
+    });
+
+    it("bfs still calls mutation for root cycles when skipFirstMutation is true", () => {
+      const schema: any = { title: "a", items: {} };
+      schema.items = schema;
+      const mockMutation = jest.fn((s) => s);
+
+      traverse(schema as JSONSchema, mockMutation, { bfs: true, skipFirstMutation: true, mutable: true });
+
+      expect(mockMutation).toHaveBeenCalledTimes(1);
+      expect(mockMutation).toHaveBeenCalledWith(
+        schema,
+        true,
+        expect.any(String),
+        schema
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- cover cycle handling in bfs mode
- verify bfs works with skip-first and cyclical refs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550d0a8428832f98ea7b83c2085c14