### PR TITLE
Implement additional JSON Schema keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ traverse(mySchema, (schemaOrSubschema) => {
 
 https://json-schema-tools.github.io/traverse/
 
-## Features Todo
-
- - unevaluatedItems (https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.3.1.3)
- - unevaluatedProperties (https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.3.2.4)
- - contains (https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.3.1.4)
- - propertyNames (https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.3.2.5)
-
 ### Contributing
 
 How to contribute, build and release are outlined in [CONTRIBUTING.md](CONTRIBUTING.md), [BUILDING.md](BUILDING.md) and [RELEASING.md](RELEASING.md) respectively. Commits in this repository follow the [CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md) specification.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -622,6 +622,109 @@ describe("traverse", () => {
     });
   });
 
+    it("traverses contains", () => {
+      const testSchema: any = {
+        contains: { type: "string" }
+      };
+      const mockMutation = jest.fn((mockS) => mockS);
+
+      traverse(testSchema, mockMutation);
+
+      expect(mockMutation).nthCalledWith(
+        1,
+        testSchema.contains,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockMutation).nthCalledWith(
+        2,
+        testSchema,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
+
+      expect(mockMutation).toHaveBeenCalledTimes(2);
+    });
+
+    it("traverses propertyNames", () => {
+      const testSchema: any = {
+        propertyNames: { type: "string" }
+      };
+      const mockMutation = jest.fn((mockS) => mockS);
+
+      traverse(testSchema, mockMutation);
+
+      expect(mockMutation).nthCalledWith(
+        1,
+        testSchema.propertyNames,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockMutation).nthCalledWith(
+        2,
+        testSchema,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
+
+      expect(mockMutation).toHaveBeenCalledTimes(2);
+    });
+
+    it("traverses unevaluatedItems as boolean", () => {
+      const testSchema: any = {
+        unevaluatedItems: false,
+      };
+      const mockMutation = jest.fn((mockS) => mockS);
+
+      traverse(testSchema, mockMutation);
+
+      expect(mockMutation).nthCalledWith(
+        1,
+        testSchema.unevaluatedItems,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockMutation).nthCalledWith(
+        2,
+        testSchema,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
+
+      expect(mockMutation).toHaveBeenCalledTimes(2);
+    });
+
+    it("traverses unevaluatedProperties as schema", () => {
+      const testSchema: any = {
+        unevaluatedProperties: { type: "string" },
+      };
+      const mockMutation = jest.fn((mockS) => mockS);
+
+      traverse(testSchema, mockMutation);
+
+      expect(mockMutation).nthCalledWith(
+        1,
+        testSchema.unevaluatedProperties,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockMutation).nthCalledWith(
+        2,
+        testSchema,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
+
+    expect(mockMutation).toHaveBeenCalledTimes(2);
+  });
 
   describe("schema.type being an array", () => {
     it("allows type to be an array", () => {
@@ -1041,8 +1144,6 @@ describe("traverse", () => {
       testCalls(mockMutation, testSchema.properties.foo.items[1], false, 4);
     });
   });
-});
-
 describe("Mutability settings", () => {
   it("defaults to being immutable", () => {
     const s = {
@@ -1214,4 +1315,5 @@ describe("Mutability settings", () => {
       expect((result.properties as Properties).foo).toBe(s.properties.foo);
     });
   });
+});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,20 @@ export default function traverse(
       );
     }
 
+    if (schema.contains !== undefined) {
+      mutableSchema.contains = rec(
+        schema.contains,
+        [...pathStack, "contains"],
+      );
+    }
+
+    if (schema.unevaluatedItems !== undefined) {
+      mutableSchema.unevaluatedItems = rec(
+        schema.unevaluatedItems,
+        [...pathStack, "unevaluatedItems"],
+      );
+    }
+
     if (schema.properties !== undefined) {
       const sProps: { [key: string]: JSONSchema } = schema.properties;
       const mutableProps: { [key: string]: JSONSchema } = {};
@@ -262,6 +276,20 @@ export default function traverse(
 
     if (schema.additionalProperties !== undefined && !!schema.additionalProperties === true) {
       mutableSchema.additionalProperties = rec(schema.additionalProperties, [...pathStack, "additionalProperties"]);
+    }
+
+    if (schema.propertyNames !== undefined) {
+      mutableSchema.propertyNames = rec(
+        schema.propertyNames,
+        [...pathStack, "propertyNames"],
+      );
+    }
+
+    if (schema.unevaluatedProperties !== undefined && !!schema.unevaluatedProperties === true) {
+      mutableSchema.unevaluatedProperties = rec(
+        schema.unevaluatedProperties,
+        [...pathStack, "unevaluatedProperties"],
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- support `contains`, `propertyNames`, `unevaluatedItems` and `unevaluatedProperties`
- add tests for new keywords
- clean up README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550ccfe4e8832fb3c851a787f85996